### PR TITLE
Changed I to K... the started binding to tab, which was very very bad.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Summary
 `fzf-gcloud` is a [`zsh`](https://en.wikipedia.org/wiki/Z_shell) script lets you browse the [`gcloud`](https://cloud.google.com/sdk/gcloud/) CLI api with [`fzf`](https://github.com/junegunn/fzf).
 
-It adds a keybinding on `CTRL-I` (like *I*nformation) to browse the currently installed `gcloud` CLI API with `fzf`, to help navigate the many commands quickly:
+It adds a keybinding on `CTRL-K` (like *cloud* ... meh) to browse the currently installed `gcloud` CLI API with `fzf`, to help navigate the many commands quickly:
 ![Usage preview](usage_preview.gif)
 
 ## Requirements
@@ -27,7 +27,7 @@ Please note that the branch to checkout is `main`, which must be specified in th
 ```
 antigen bundle 'mbhynes/fzf-gcloud' --branch=main
 ```
-The first time you use `CTRL-I`, the `gcloud` command cache will be populated. 
+The first time you use `CTRL-K`, the `gcloud` command cache will be populated. 
 
 Don't panic. 
 
@@ -49,13 +49,13 @@ zgen load 'mbhynes/fzf-gcloud' 'main'
 ```
 
 ### Usage
-- The widget is by default bound to the keybinding `CTRL-I` (`'^I'`)
+- The widget is by default bound to the keybinding `CTRL-K` (`'^K'`)
 - You can alter this by changing the `bindkey` line in the `.fzf-gcloud.plugin.zsh` or `~/.antigen/bundles/mbhynes/fzf-gcloud-main/fzf-gcloud.plugin.zsh` (or wherever you've placed it in your system), as noted below:
 
 ```zsh
 fzf-gcloud-widget() {
   # ==========================================================================
-  # Bind the gcloud fzf helper to CTRL-I
+  # Bind the gcloud fzf helper to CTRL-K
   # ==========================================================================
   LBUFFER="$(__gcloud_sel)"
   local ret=$?
@@ -63,7 +63,7 @@ fzf-gcloud-widget() {
   return $ret
 }
 zle     -N   fzf-gcloud-widget
-bindkey '^I' fzf-gcloud-widget # <--- change if you prefer a different keybinding
+bindkey '^K' fzf-gcloud-widget # <--- change if you prefer a different keybinding
 ```
 
 ## Implementation Details

--- a/fzf-gcloud.plugin.zsh
+++ b/fzf-gcloud.plugin.zsh
@@ -137,7 +137,7 @@ fzf-gcloud-widget() {
 }
 # Bind the gcloud fzf helper to CTRL-I
 zle     -N   fzf-gcloud-widget
-bindkey '^I' fzf-gcloud-widget
+bindkey '^k' fzf-gcloud-widget
 
 } always {
   eval $__fzf_key_bindings_options


### PR DESCRIPTION
## Summary
- Closes https://github.com/mbhynes/fzf-gcloud/issues/3 (again ...) 

## Changes
- The default keybinding is now `CTRL-K`, like "cloud" with a k.
- The CTRL-I keybinding, while working, had some side effect that triggered the widget on `<tab>` 

## Testing
```bash
antigen purge mbhynes/fzf-gcloud
antigen bundle mbhynes/fzf-gcloud --branch=update-default-keybinding
```

## Impact
- Hopefully this isn't too disruptive to the userbase of 1? lol sorry @farzadmf my bad