### PR TITLE
Added link to fzf upstream in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It adds a keybinding on `CTRL-K` (like *cloud* ... meh) to browse the currently 
 ![Usage preview](usage_preview.gif)
 
 ## Requirements
-- `fzf` (`brew install fzf`)
+- `fzf` (Please see the instructions [upstream for fzf](https://github.com/junegunn/fzf), but generally: `brew install fzf` & `$(brew --prefix)/opt/fzf/install`)
 - `gcloud` (`brew install --cask google-cloud-sdk`)
 - `sqlite3` (`brew install sqlite`)
 


### PR DESCRIPTION
## Issue
https://github.com/mbhynes/fzf-gcloud/issues/10

## Testing
Previewed at https://github.com/mbhynes/fzf-gcloud/tree/41b7a4c0ecb9919e5743907a7dfcf16fd57018fd:
![image](https://user-images.githubusercontent.com/10452129/135778040-4e4a5937-c02a-48be-a130-5f56867469de.png)
